### PR TITLE
Mv sl quicker

### DIFF
--- a/njs/src/tradebb/position-check.js
+++ b/njs/src/tradebb/position-check.js
@@ -192,7 +192,7 @@ const handlePosition = async (pos) => {
 
       if (
         !activeTpOrders.length
-        && currPNL > 0.35
+        && currPNL > 0.25
         && Number(pos.stopLoss) !== Number(newSl)
       ) {
 


### PR DESCRIPTION
There was the case that TP1 got hit but SL didn't move because the required pnl was too far away.