### PR TITLE
Add container restart to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       APP_DOCKER: True
     env_file:
       - ./njs/.env
+    restart: always
   rsignals:
     build: ./rsignals
     # ports:
@@ -16,3 +17,5 @@ services:
       APP_DOCKER: True
     env_file:
       - ./njs/.env
+    # see https://docs.docker.com/config/containers/start-containers-automatically/ & https://www.baeldung.com/ops/docker-compose-restart-policies
+    restart: always


### PR DESCRIPTION
There was an incident that the rsignal stopped working, not sure of the reason. This commit brings the compose restart, additionally health check is needed.