### PR TITLE
Set volume report to show 30 bb pairs

### DIFF
--- a/rsignals/src/rsignals/engine/envs.clj
+++ b/rsignals/src/rsignals/engine/envs.clj
@@ -122,7 +122,7 @@
   (let [length (if (System/getenv "DYNAMIC_TICKERS_LENGTH")
                  (Integer/parseInt
                   (System/getenv "DYNAMIC_TICKERS_LENGTH"))
-                 13)
+                 30)
         tickers-vol-ms (ohlc/get-tickers-by-vol-desc length)]
     (try
       (discord/log (with-out-str


### PR DESCRIPTION
Set volume report to show 30 bb pairs by default.